### PR TITLE
use os/exec to start and kill phantomjs

### DIFF
--- a/process_darwin.go
+++ b/process_darwin.go
@@ -1,9 +1,0 @@
-package phantomjs
-
-import (
-	"syscall"
-)
-
-func killProcess(pid int, handlePtr uintptr) {
-	syscall.Kill(pid, syscall.SIGKILL)
-}

--- a/process_linux.go
+++ b/process_linux.go
@@ -1,9 +1,0 @@
-package phantomjs
-
-import (
-	"syscall"
-)
-
-func killProcess(pid int, handlePtr uintptr) {
-	syscall.Kill(pid, syscall.SIGKILL)
-}

--- a/process_windows.go
+++ b/process_windows.go
@@ -1,9 +1,0 @@
-package phantomjs
-
-import (
-	"syscall"
-)
-
-func killProcess(pid int, handlePtr uintptr) {
-	syscall.TerminateProcess(syscall.Handle(handlePtr), 0)
-}


### PR DESCRIPTION
os/exec有代码中需要的所有功能。不知道为什么自己实现
os/exec has all features we need, such as stdin/stdout/stderr redirect, start/kill process .i'm curious why we implement by our own.
